### PR TITLE
Fixed missing quotation mark

### DIFF
--- a/probeRC.py
+++ b/probeRC.py
@@ -85,7 +85,7 @@ def main():
     # Allow user to input parameters on command line.
     userInput = argparse.ArgumentParser(description=\
         '%s version %s. Requires a .bed file with first four columns in the '
-        'format chromosome <tab> start <tab> stop <tab> sequence <tab> Tm such
+        'format chromosome <tab> start <tab> stop <tab> sequence <tab> Tm such'
 	' as the .bed files produced by outputClean. Returns a .bed file that is '
         'identical to the input file except that the probe sequences have been '
         'replaced with their reverse complements.' % (scriptName, Version))


### PR DESCRIPTION
Hi Brian, long time no see! Noticed that `probeRC.py` yields `SyntaxError` because of a missing quotation mark from your recent help text typo fix.